### PR TITLE
Fix incorrect removal of modals

### DIFF
--- a/src/app/_services/modal.service.ts
+++ b/src/app/_services/modal.service.ts
@@ -18,7 +18,7 @@ export class ModalService {
 
     remove(modal: ModalComponent) {
         // remove modal from array of active modals
-        this.modals = this.modals.filter(x => x === modal);
+        this.modals = this.modals.filter(x => x !== modal);
     }
 
     open(id: string) {


### PR DESCRIPTION
Previously the ModalService remove method was removing all modals except the current one. Updated the method to correctly remove the current modal only and keep all others.